### PR TITLE
decoupled scoreRange into scoreMin and scoreMax + setting scoreMax=0 …

### DIFF
--- a/src/Components/EssentialitiesPlot/index.js
+++ b/src/Components/EssentialitiesPlot/index.js
@@ -234,7 +234,8 @@ function essentialitiesPlot(props) {
       geneId: urlParams.geneId,
       modelId: urlParams.modelId,
       tissue: urlParams.tissue,
-      scoreRange: urlParams.score,
+      scoreMin: urlParams.scoreMin,
+      scoreMax: urlParams.scoreMax,
       pageSize: 0,
     };
 
@@ -246,7 +247,7 @@ function essentialitiesPlot(props) {
         resize();
         setData(resp.data)
       })
-  }, [urlParams.geneId, urlParams.modelId, urlParams.tissue, JSON.stringify(urlParams.score)]);
+  }, [urlParams.geneId, urlParams.modelId, urlParams.tissue, urlParams.scoreMin, urlParams.scoreMax]);
 
   const yAxisLabel = attributeToPlot === 'fc_clean' ?
     FC_CLEAN_LABEL :

--- a/src/Components/ModelInfoSummary/index.js
+++ b/src/Components/ModelInfoSummary/index.js
@@ -16,7 +16,6 @@ function ModelInfoSummary(props) {
     setLoading(true);
     fetchModelInfo(urlParams.modelId)
       .then(modelInfo => {
-        console.log(modelInfo);
         setLoading(false);
         setModelName(modelInfo.names[0]);
         setGrowProperties(modelInfo.growthProperties);

--- a/src/Components/ScoreRangeFilter/index.js
+++ b/src/Components/ScoreRangeFilter/index.js
@@ -10,14 +10,17 @@ import Spinner from '../Spinner';
 function ScoreRangeFilter(props) {
   const [urlParams, , setUrlParams] = useUrlParams(props, 500);
 
-  const [scoreRange, setScoreRange] = useState(urlParams.score);
+  const [scoreMin, setScoreMin] = useState(urlParams.scoreMin);
+  const [scoreMax, setScoreMax] = useState(urlParams.scoreMax);
   const [scoreExtent, setScoreExtent] = useState(null);
   const [loading, setLoading] = useState(false);
 
   const onChange = (range) => {
-    setScoreRange(range);
+    setScoreMin(range[0]);
+    setScoreMax(range[1]);
     setUrlParams({
-      score: range,
+      scoreMin: range[0],
+      scoreMax: range[1],
     })
   };
 
@@ -43,13 +46,19 @@ function ScoreRangeFilter(props) {
     );
   }
 
+  console.log(`scoreMin: ${scoreMin} - scoreMax: ${scoreMax}`);
+  const scoreRange = [
+    scoreMin === undefined ? scoreExtent[0] : +scoreMin,
+    scoreMax === undefined ? scoreExtent[1] : +scoreMax,
+  ];
+
   return (
     <Spinner loading={loading}>
       <Range
         allowCross={false}
         min={scoreExtent[0]}
         max={scoreExtent[1]}
-        value={scoreRange || scoreExtent}
+        value={scoreRange}
         step={0.00001}
         defaultValue={scoreExtent}
         onChange={onChange}

--- a/src/Components/SearchExamples/index.js
+++ b/src/Components/SearchExamples/index.js
@@ -9,7 +9,7 @@ function SearchExamples() {
         Try:
         <Link to={'/gene/SIDG02491'}>BRAF</Link>
         <Link to={'/gene/SIDG26200'}>PTEN</Link>
-        <Link to={'/model/SIDM01197'}>SNU-C1</Link>
+        <Link to={'/model/SIDM01197?scoreMax=0'}>SNU-C1</Link>
         <Link to={'/table?tissue=Breast'}>Breast</Link>
         <span style={{marginLeft: '20px'}}>
                 Or:<Link to={'/table'}>explore all the data</Link>

--- a/src/Components/Table/index.js
+++ b/src/Components/Table/index.js
@@ -53,7 +53,8 @@ function Table(props) {
       pageNumber,
       search,
       tissue: urlParams.tissue,
-      scoreRange: urlParams.score,
+      scoreMin: urlParams.scoreMin,
+      scoreMax: urlParams.scoreMax,
     };
 
     setLoading(true);
@@ -72,7 +73,8 @@ function Table(props) {
     pageNumber,
     search,
     urlParams.tissue,
-    JSON.stringify(urlParams.score),
+    urlParams.scoreMin,
+    urlParams.scoreMax,
   ]);
 
   const isFirstPage = pageNumber === 1;

--- a/src/Components/TableDisplay/index.js
+++ b/src/Components/TableDisplay/index.js
@@ -68,7 +68,7 @@ function TableDisplay(props) {
                 <Link to={`/gene/${row.geneId}?${paramsForGeneLink}`}>{row.geneSymbol}</Link>
               </td>
               <td style={{whiteSpace: 'nowrap'}}>
-                <Link to={`/model/${row.modelId}?${paramsForModelLink}`}>{row.modelName}</Link>
+                <Link to={`/model/${row.modelId}?${paramsForModelLink}&scoreMax=0`}>{row.modelName}</Link>
               </td>
               <td>
                 {row.tissue}

--- a/src/Components/useUrlParams/index.js
+++ b/src/Components/useUrlParams/index.js
@@ -28,13 +28,13 @@ const _deferredSetUrlParams = debounce(_setUrlParams, 500);
 
 
 function useUrlParams(props) {
-  const {tissue, score: scoreRaw} = qs.parse(props.location.search);
-  const score = scoreRaw ? JSON.parse(scoreRaw) : null;
+  const {tissue, scoreMin, scoreMax} = qs.parse(props.location.search);
   const {geneId, modelId} = props.match.params;
 
   const urlParams = {
     tissue,
-    score,
+    scoreMin,
+    scoreMax,
     geneId,
     modelId,
   };

--- a/src/api/fetchCrisprData.js
+++ b/src/api/fetchCrisprData.js
@@ -24,8 +24,11 @@ function normaliseParams(params) {
     expandSearchFilter(params.search) :
     null;
 
-  const scoreRangeFilter = params.scoreRange ?
-    expandScoreRangeFilter(params.scoreRange) :
+  const scoreRangeFilter = params.scoreMin || params.scoreMax ?
+    expandScoreRangeFilter({
+      scoreMin: params.scoreMin,
+      scoreMax: params.scoreMax
+    }) :
     null;
 
   const tissueFilter = params.tissue ?

--- a/src/api/filters.js
+++ b/src/api/filters.js
@@ -47,7 +47,7 @@ export function expandModelFilter(modelId) {
 
 export function expandSearchFilter(search) {
   return {
-        or: [
+    or: [
       {
         name: 'model_name',
         op: 'contains',
@@ -62,21 +62,35 @@ export function expandSearchFilter(search) {
   }
 }
 
-export function expandScoreRangeFilter(scoreRange) {
-  return {
-    and: [
-      {
-        name: 'fc_clean',
-        op: 'ge',
-        val: scoreRange[0],
-      },
-      {
-        name: 'fc_clean',
-        op: 'le',
-        val: scoreRange[1],
-      }
-    ],
+export function expandScoreRangeFilter({scoreMin, scoreMax}) {
+  const scoreMinFilter = {
+    name: 'fc_clean',
+    op: 'ge',
+    val: scoreMin,
   };
+
+  const scoreMaxFilter = {
+    name: 'fc_clean',
+    op: 'le',
+    val: scoreMax,
+  };
+
+  if (scoreMin && scoreMax) {
+    return {
+      and: [
+        scoreMinFilter,
+        scoreMaxFilter,
+      ]
+    }
+  }
+
+  if (scoreMin) {
+    return scoreMinFilter;
+  }
+
+  if (scoreMax) {
+    return scoreMaxFilter;
+  }
 }
 
 export function combineFilters(filters) {


### PR DESCRIPTION
…by default when linking to the models page

@Donnyvdm, I think it has been suggested to load only the significant genes in the models page by default to speed up the query. I can't find that request now, but this PR basically tries to do that. It is basically setting a default max value of `fc_clean` to 0. Is that sensible? If so, I think this is the cleanest way I can think of implementing this.
